### PR TITLE
Potential fix for code scanning alert no. 5: Unsigned difference expression compared to zero

### DIFF
--- a/opencog/util/lazy_selector.cc
+++ b/opencog/util/lazy_selector.cc
@@ -39,7 +39,7 @@ namespace opencog
 lazy_selector::lazy_selector(unsigned int u, unsigned int l)
     : _u(u), _l(l)
 {
-    OC_ASSERT(u - l > 0, "you cannot select any thing from an empty list");
+    OC_ASSERT(u > l, "you cannot select any thing from an empty list");
 }
 
 bool lazy_selector::empty() const


### PR DESCRIPTION
Potential fix for [https://github.com/OzCog/cogutil/security/code-scanning/5](https://github.com/OzCog/cogutil/security/code-scanning/5)

To fix the issue, the comparison `u - l > 0` should be replaced with `u > l`. This avoids the unsigned subtraction and directly checks the intended condition. The logic remains the same, but the fix ensures correctness even when `l > u`.

**Steps to implement the fix:**
1. Locate the assertion on line 42 in the file `opencog/util/lazy_selector.cc`.
2. Replace `u - l > 0` with `u > l` to correctly check the condition without relying on unsigned subtraction.

No additional imports, methods, or definitions are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
